### PR TITLE
Learned How to Spell Geometry

### DIFF
--- a/rb_ws/src/buggy/package.xml
+++ b/rb_ws/src/buggy/package.xml
@@ -49,16 +49,16 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>goemetry_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>microstrain_inertial_msgs</build_depend>
-  <build_export_depend>goemetry_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>goemetry_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>


### PR DESCRIPTION
The package geometry messages turned out to be misspelled for months, which prevented building dependencies from source since it would stop when it would fail to resolve 'goemetry_msgs'.  This branch merely fixes that for my own sense of sanity, even if it doesn't actually make any difference.