### PR TITLE
Support for specifying controller in roslaunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Instructions:
 - While in a bash shell with the X11 server running, run `xhost +local:docker`.
 - Boot up the docker container using the "Alternate Shortcut" above.
 - Run `xeyes` while INSIDE the Docker container to test X11 forwarding. If this works, we're good.
-- Run `roslaunch buggy sim_2d.launch` for the simulator.
+- Run `roslaunch buggy sim_2d.launch controller:=CONTROLLER_TYPE` for the simulator.
 
 ### Using the Simulator
 Feedback:

--- a/rb_ws/src/buggy/launch/main.launch
+++ b/rb_ws/src/buggy/launch/main.launch
@@ -1,7 +1,7 @@
 <!-- roslaunch buggy main.launch -->
 
 <launch>
-
+    <arg name="controller"      default="stanley" />
     <include file="$(find microstrain_inertial_driver)/launch/microstrain.launch">
         <arg name="params_file" value="/rb_ws/src/buggy/INS_params.yml"/>
     </include>
@@ -24,5 +24,5 @@
     <node name="telematics" pkg="buggy" type="telematics.py" />
 
     <!-- ENABLE AUTON -->
-    <node name="auton_system" pkg="buggy" type="autonsystem.py" output="screen"/>
+    <node name="auton_system" pkg="buggy" type="autonsystem.py" output="screen" args="$(arg controller)"/>
 </launch>

--- a/rb_ws/src/buggy/launch/sim_2d.launch
+++ b/rb_ws/src/buggy/launch/sim_2d.launch
@@ -3,11 +3,12 @@
 <!-- <arg name="name" value="INS" /> -->
 
 <launch>
+    <arg name="controller"      default="stanley" />
     <node name="foxglove" pkg="foxglove_bridge" type="foxglove_bridge" />
     
     <node name="sim_2d_engine" pkg="buggy" type="engine.py" output="screen"/>
     <node name="sim_2d_visualizer" pkg="buggy" type="grapher.py" output="screen"/>
     <node name="sim_2d_controller" pkg="buggy" type="controller_2d.py" output="screen"/>
 
-    <node name="auton_system" pkg="buggy" type="autonsystem.py" output="screen"/>
+    <node name="auton_system" pkg="buggy" type="autonsystem.py" output="screen" args="$(arg controller)"/>
 </launch>

--- a/rb_ws/src/buggy/scripts/auton/autonsystem.py
+++ b/rb_ws/src/buggy/scripts/auton/autonsystem.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import rospy
+import sys
 
 # ROS Message Imports
 from std_msgs.msg import Float32, Float64
@@ -96,10 +97,23 @@ class AutonSystem:
 
 if __name__ == "__main__":
     rospy.init_node("auton_system")
+
+    arg = sys.argv[1]
+    print("\n\nStarting Controller: " + str(arg) + "\n\n")
+
+    # Add Controllers Here
+    ctrller = None
+    if (arg == "stanley"):
+        ctrller = StanleyController()
+    elif (arg == "pure_pursuit"):
+        ctrller = PurePursuitController()
+
+    if (ctrller == None):
+        raise Exception("Invalid Controller Argument")
+
     auton_system = AutonSystem(
         Trajectory("/rb_ws/src/buggy/paths/buggycourse_raceline.json"),
-        # PurePursuitController(),
-        StanleyController(),
+        ctrller,
         BrakeController()
     )
     while not rospy.is_shutdown():


### PR DESCRIPTION
Can you try running it? Details also in readme but run:

roslaunch buggy sim_2d.launch controller:=CONTROLLER_TYPE

can be "stanley" or "pure_pursuit".

Can add "mpc" once you finish that - just take a look at the bottom on autonsystem.py