### PR TITLE
fixed busy loop bug in path planner

### DIFF
--- a/rb_ws/src/buggy/scripts/auton/autonsystem.py
+++ b/rb_ws/src/buggy/scripts/auton/autonsystem.py
@@ -167,18 +167,23 @@ class AutonSystem:
         with self.lock:
             _, _ = self.get_world_pose_and_speed(self.self_odom_msg)
 
-        p2 = threading.Thread(target=self.planner_thread)
-        p1 = threading.Thread(target=self.local_controller_thread)
+        t_planner = threading.Thread(target=self.planner_thread)
+        t_controller = threading.Thread(target=self.local_controller_thread)
 
         # starting processes
         # See LOOKAHEAD_TIME in path_planner.py for the horizon of the
         # planner. Make sure it is significantly (at least 2x) longer
         # than 1 period of the planner when you change the planner frequency.
-        p2.start() #Planner runs every 10 hz
-        p1.start() #Main Cycles runs at 100hz
 
-        p2.join()
-        p1.join()
+
+        t_controller.start() #Main Cycles runs at 100hz
+        if self.has_other_buggy:
+            t_planner.start() #Planner runs every 10 hz
+
+        t_controller.join()
+        if self.has_other_buggy:
+            t_planner.join()
+
 
     def get_world_pose_and_speed(self, msg):
         current_rospose = msg.pose.pose
@@ -209,6 +214,7 @@ class AutonSystem:
 
     def planner_thread(self):
         while (not rospy.is_shutdown()):
+            self.rosrate_planner.sleep()
             if not self.other_odom_msg is None:
                 with self.lock:
                     self_pose, _ = self.get_world_pose_and_speed(self.self_odom_msg)
@@ -218,7 +224,6 @@ class AutonSystem:
                     self.distance_publisher.publish(Float64(distance))
 
                 self.planner_tick()
-                self.rosrate_planner.sleep()
 
 
     def planner_tick(self):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed busy looping in path planning thread in autonsystem.py caused by only sleeping if NAND odom exists. Added logic to only start path planning thread if other buggy exists. Added logic to run the path planning thread at the correct frequency even if the other buggy's position is uninitialized.

## Testing, QA instruction

Run roslaunch buggy sim_2d_2buggies.launch and roslaunch buggy sim_2d_single.launch. Both simulations should work correctly and maintain a data rate above ~50 hz in the steering angle topic.
