### PR TITLE
changed telematics to visualize nand position

### DIFF
--- a/rb_ws/src/buggy/scripts/visualization/telematics.py
+++ b/rb_ws/src/buggy/scripts/visualization/telematics.py
@@ -15,7 +15,6 @@ class Telematics:
         """Generate all the subscribers and publishers that need to be reformatted.
         """
 
-        # TODO: add buggy name to argparse
         self.odom_subscriber = rospy.Subscriber("/NAND/nav/odom", Odometry, self.convert_odometry_to_navsatfix)
         self.odom_publisher = rospy.Publisher("/NAND/nav/odom_NavSatFix", NavSatFix, queue_size=10)
 

--- a/rb_ws/src/buggy/scripts/visualization/telematics.py
+++ b/rb_ws/src/buggy/scripts/visualization/telematics.py
@@ -14,8 +14,10 @@ class Telematics:
     def __init__(self):
         """Generate all the subscribers and publishers that need to be reformatted.
         """
-        self.odom_subscriber = rospy.Subscriber("/nav/odom", Odometry, self.convert_odometry_to_navsatfix)
-        self.odom_publisher = rospy.Publisher("/nav/odom_NavSatFix", NavSatFix, queue_size=10)
+
+        # TODO: add buggy name to argparse
+        self.odom_subscriber = rospy.Subscriber("/NAND/nav/odom", Odometry, self.convert_odometry_to_navsatfix)
+        self.odom_publisher = rospy.Publisher("/NAND/nav/odom_NavSatFix", NavSatFix, queue_size=10)
 
         self.gnss1_pose_publisher = rospy.Publisher("/gnss1/fix_Pose", PoseStamped, queue_size=10)
         self.gnss1_covariance_publisher = rospy.Publisher("/gnss1/fix_FloatArray_Covariance", Float64MultiArray, queue_size=10)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
After an update, the INS driver publishes SC's position as a NavSatFix, which can be visualized by Foxglove. Therefore, there is no longer a need for telematics.py to republish SC position as a NavSatFix. However, NAND's position does need to be republished in order for it to be visualized

## QA Instructions, Screenshots, Recordings
Run auton on SC with NAND communicating to it. Check on foxglove is NAND position is correctly displayed.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: non-critical feature, 2 lines changed
- [ ] I need help with writing tests