### PR TITLE
Input/Debug Steering Deviation Sanity Alarm

### DIFF
--- a/rb_ws/src/buggy/launch/nand-system.launch
+++ b/rb_ws/src/buggy/launch/nand-system.launch
@@ -6,4 +6,5 @@
 
     <node name="foxglove" pkg="foxglove_bridge" type="foxglove_bridge" />
     <node name="telematics" pkg="buggy" type="telematics.py" />
+    <node name="watchdog" pkg="buggy" type="watchdog.py" args = "--self_name NAND" output="screen"/>
 </launch>

--- a/rb_ws/src/buggy/launch/sc-system.launch
+++ b/rb_ws/src/buggy/launch/sc-system.launch
@@ -14,5 +14,5 @@
 
     <node name="foxglove" pkg="foxglove_bridge" type="foxglove_bridge" />
     <node name="telematics" pkg="buggy" type="telematics.py" />
-    <node name="watchdog" pkg="buggy" type="watchdog.py" args = "--self_name SC" />
+    <node name="watchdog" pkg="buggy" type="watchdog.py" args = "--self_name SC" output="screen"/>
 </launch>

--- a/rb_ws/src/buggy/launch/sc-system.launch
+++ b/rb_ws/src/buggy/launch/sc-system.launch
@@ -14,4 +14,5 @@
 
     <node name="foxglove" pkg="foxglove_bridge" type="foxglove_bridge" />
     <node name="telematics" pkg="buggy" type="telematics.py" />
+    <node name="watchdog" pkg="buggy" type="watchdog.py" args = "--self_name SC" />
 </launch>

--- a/rb_ws/src/buggy/launch/watchdog.launch
+++ b/rb_ws/src/buggy/launch/watchdog.launch
@@ -2,5 +2,5 @@
 
 <launch>
     <node name="foxglove" pkg="foxglove_bridge" type="foxglove_bridge" />
-    <node name="watchdog" pkg="buggy" type="watchdog.py" args = "--self_name SC" />
+    <node name="watchdog" pkg="buggy" type="watchdog.py" args = "--self_name SC" output="screen"/>
 </launch>

--- a/rb_ws/src/buggy/launch/watchdog.launch
+++ b/rb_ws/src/buggy/launch/watchdog.launch
@@ -1,0 +1,6 @@
+<!-- roslaunch buggy main.launch -->
+
+<launch>
+    <node name="foxglove" pkg="foxglove_bridge" type="foxglove_bridge" />
+    <node name="watchdog" pkg="buggy" type="watchdog.py" args = "--self_name SC" />
+</launch>

--- a/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
+++ b/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
@@ -100,13 +100,14 @@ class Translator:
         alarm ros topic reader, locked so that only one of the setters runs at once
         """
         with self.lock:
+            rospy.logdebug(f"Reading alarm of {msg.data}")
             self.alarm = msg.data
 
     def set_steering(self, msg):
         """
         Steering Angle Updater, updates the steering angle locally if updated on ros stopic
         """
-        rospy.loginfo(f"Read steeering angle of: {msg.data}")
+        rospy.logdebug(f"Read steeering angle of: {msg.data}")
         # print("Steering angle: " + str(msg.data))
         # print("SET STEERING: " + str(msg.data))
         with self.lock:
@@ -120,7 +121,7 @@ class Translator:
         TODO: Does alarm node exist for NAND?
         """
         rospy.loginfo("Starting sending alarm and steering to teensy!")
-        while True:
+        while not rospy.is_shutdown():
             if self.fresh_steer:
                 with self.lock:
                     self.comms.send_steering(self.steer_angle)
@@ -139,7 +140,7 @@ class Translator:
         tuple -> (SC, maybe NAND?) Debug Info
         """
         rospy.loginfo("Starting reading odom from teensy!")
-        while True:
+        while not rospy.is_shutdown():
             packet = self.comms.read_packet()
 
             if isinstance(packet, Odometry):

--- a/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
+++ b/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
@@ -42,27 +42,14 @@ class Translator:
         """
         self.comms = Comms("/dev/" + teensy_name)
         self.steer_angle = 0
-        self.debug_steer = 0
-
         self.alarm = 0
-        self.alarm_counter = 0
-
         self.fresh_steer = False
-        self.fresh_debug_steer = False
-
         self.lock = Lock()
-
-        self.SANITY_THRESHOLD = 2  # Threshold for deviation in steering
-        self.ALARM_THRESHOLD = 3  # Threshold for the number of consecutive alarms
-        self.DEVIATION_ALARM_STATUS_CODE = 501  # Deviation alarm status code
 
         rospy.Subscriber(
             self_name + "/buggy/input/steering", Float64, self.set_steering
         )
         rospy.Subscriber(self_name + "/debug/sanity_warning", Int8, self.set_alarm)
-        rospy.Subscriber(
-            self_name + "/buggy/debug/steering", Float64, self.set_debug_steering
-        )
 
         # ISSUE: https://github.com/CMU-Robotics-Club/RoboBuggy2/issues/83
         if other_name is None and self_name == "NAND":
@@ -117,7 +104,7 @@ class Translator:
 
     def set_steering(self, msg):
         """
-        Steering Angle Updater, updates the steering angle locally if updated on ros topic
+        Steering Angle Updater, updates the steering angle locally if updated on ros stopic
         """
         rospy.loginfo(f"Read steeering angle of: {msg.data}")
         # print("Steering angle: " + str(msg.data))
@@ -125,14 +112,6 @@ class Translator:
         with self.lock:
             self.steer_angle = msg.data
             self.fresh_steer = True
-
-    def set_debug_steering(self, msg):
-        """
-        Debug Steering Angle Updater, updates debug steering angle locally if updated on ros topic
-        """
-        with self.lock:
-            self.debug_steer = msg.data
-            self.fresh_debug_steer = True
 
     def writer_thread(self):
         """
@@ -146,37 +125,6 @@ class Translator:
                 with self.lock:
                     self.comms.send_steering(self.steer_angle)
                     self.fresh_steer = False
-
-            # Sanity check between debug steering and input steering
-            if self.fresh_debug_steer:
-                with self.lock:
-                    # Check for deviation between input and debug steering
-                    deviation = abs(self.steer_angle - self.debug_steer)
-                    if deviation > self.SANITY_THRESHOLD:
-                        # Increment the alarm counter if deviation exceeds threshold
-                        self.alarm_counter += 1
-                        rospy.logwarn(
-                            "Sanity check failed. Deviation between input and debug steering is: "
-                            + str(deviation)
-                            + ". Incrementing alarm counter to: "
-                            + str(self.alarm_counter)
-                            + "."
-                        )
-                    else:
-                        # Reset alarm counter if steering is within threshold
-                        self.alarm_counter = 0
-
-                    # Check if alarm counter exceeds the maximum allowed
-                    if self.alarm_counter > self.ALARM_THRESHOLD:
-                        self.alarm = self.ALARM_STATUS_CODE
-                        rospy.logerr(
-                            "Alarm status set to "
-                            + str(self.DEVIATION_ALARM_STATUS_CODE)
-                            + "due to repeated sanity check failures."
-                        )
-
-                    # Reset the flag to avoid reprocessing until a new message arrives
-                    self.fresh_debug_steer = False
 
             with self.lock:
                 self.comms.send_alarm(self.alarm)

--- a/rb_ws/src/buggy/scripts/visualization/telematics.py
+++ b/rb_ws/src/buggy/scripts/visualization/telematics.py
@@ -97,8 +97,8 @@ class Telematics:
         else:
             fix_string += "FIX_RTK_FIXED"
 
-        fix_string += "\nsbas_used: "  + str(msg.sbas_used)
-        fix_string += "\ndngss_used: " + str(msg.dngss_used)
+        # fix_string += "\nsbas_used: "  + str(msg.sbas_used)
+        # fix_string += "\ndngss_used: " + str(msg.dngss_used)
         publishers[0].publish(fix_string)
         publishers[1].publish(fix_type)
 

--- a/rb_ws/src/buggy/scripts/watchdog/watchdog.py
+++ b/rb_ws/src/buggy/scripts/watchdog/watchdog.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import argparse
+
+import rospy
+
+from std_msgs.msg import Bool, Int8, Float64
+
+class Watchdog:
+
+    STEERING_DEVIANCE = 2 #deg
+
+    def __init__(self, self_name) -> None:
+        self.alarm = 0 #Check this alarm value
+        """
+        0 - OK
+        1 - WARNING
+        2 - ERROR        
+        """
+        
+        self.commanded_steering = 0
+        self.inAutonSteer = False
+
+        rospy.Subscriber(
+            self_name + "/buggy/input/steering", Float64, self.set_input_steering
+        )
+        rospy.Subscriber(
+            self_name + "/buggy/debug/steering_angle", Float64, self.check_stepper_steering
+        )
+        rospy.Subscriber(
+            self_name + "/buggy/debug/use_auton_steer", Bool, self.check_stepper_steering
+        )
+
+        self.alarm_publisher = rospy.Publisher(self_name + "/debug/sanity_warning", Int8, queue_size=1)
+        self.alarm_publish_rate = rospy.Rate(100) #10ms per alarm
+        
+    def set_input_steering(self, msg):
+        rospy.loginfo("Got input steering of, "  + str(msg.data))
+        self.commanded_steering = msg.data
+    
+    def set_auton_steer(self, msg):        
+        self.inAutonSteer = msg.data
+
+    def check_stepper_steering(self, msg):
+        stepper_steer = msg.data
+        rospy.logdebug("Firmware's reported stepper degree: " + str(stepper_steer))
+        if abs(stepper_steer - self.commanded_steering) > Watchdog.STEERING_DEVIANCE:
+            self.alarm = 2 # ERROR
+            if self.inAutonSteer:
+                rospy.logerror("STEPPER DEVIANCE of " +  str(abs(stepper_steer - self.commanded_steering)))
+            else:
+                rospy.logdebug("Stepper Deviance of " + str((stepper_steer - self.commanded_steering)) + " but not in auton steer")
+                
+        elif abs(stepper_steer - self.commanded_steering) > Watchdog.STEERING_DEVIANCE//2:
+            if self.inAutonSteer:
+                rospy.logwarn("STEPPER POSSIBILY DEVIATING: " + str(abs(stepper_steer - self.commanded_steering)))
+            else:
+                rospy.logdebug("Not in auton, but stepper possibly deviating " + str(abs(stepper_steer - self.commanded_steering)))
+
+    def loop(self):
+        while True:
+            print("HERE")
+            #publish alarm
+            ros_alarm = Int8()
+            ros_alarm.data = self.alarm
+            self.alarm_publisher.publish(ros_alarm)
+            
+            self.alarm_publish_rate.sleep()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--self_name", type=str, help="name of ego-buggy", required=True
+    )
+    args, _ = parser.parse_known_args()
+    self_name = args.self_name
+    rospy.init_node("watchdog")
+    print("INITIALIZED")
+    rospy.loginfo("INITIALIZED WATCHDOG NODE")
+    watchdog = Watchdog(self_name=self_name)
+    watchdog.loop()
+
+
+    
+

--- a/rb_ws/src/buggy/scripts/watchdog/watchdog.py
+++ b/rb_ws/src/buggy/scripts/watchdog/watchdog.py
@@ -17,7 +17,7 @@ class Watchdog:
         1 - WARNING
         2 - ERROR        
         """
-        
+
         self.commanded_steering = 0
         self.inAutonSteer = False
 
@@ -33,12 +33,12 @@ class Watchdog:
 
         self.alarm_publisher = rospy.Publisher(self_name + "/debug/sanity_warning", Int8, queue_size=1)
         self.alarm_publish_rate = rospy.Rate(100) #10ms per alarm
-        
+
     def set_input_steering(self, msg):
         rospy.logdebug("Got input steering of: "  + str(msg.data))
         self.commanded_steering = msg.data
-    
-    def set_auton_steer(self, msg):     
+
+    def set_auton_steer(self, msg):
         if (msg.data and not self.inAutonSteer):
             rospy.loginfo("ENTERED AUTON")
         if (not msg.data and self.inAutonSteer):
@@ -54,7 +54,7 @@ class Watchdog:
                 rospy.logerr("STEPPER DEVIANCE (DEGREES OFF): " +  str(abs(stepper_steer - self.commanded_steering)))
             else:
                 rospy.logdebug("(Non Auton) Stepper Deviance of: " + str(abs(stepper_steer - self.commanded_steering)))
-                
+
         elif abs(stepper_steer - self.commanded_steering) > Watchdog.STEERING_DEVIANCE//2:
             if self.inAutonSteer:
                 rospy.logwarn("STEPPER POSSIBILY DEVIATING (DEGREES OFF):  " + str(abs(stepper_steer - self.commanded_steering)))
@@ -68,7 +68,7 @@ class Watchdog:
             ros_alarm = Int8()
             ros_alarm.data = self.alarm
             self.alarm_publisher.publish(ros_alarm)
-            
+
             self.alarm_publish_rate.sleep()
 
 if __name__ == "__main__":
@@ -82,7 +82,3 @@ if __name__ == "__main__":
     rospy.loginfo("INITIALIZED WATCHDOG NODE")
     watchdog = Watchdog(self_name=self_name)
     watchdog.loop()
-
-
-    
-


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds a sanity check to flop the alarm with status code 501 when debug steering deviates from input steering by more than degrees for more than 4 consecutive ticks (0.4 seconds).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: no
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
