### PR TITLE
Added a queue to the watchdog

### DIFF
--- a/rb_ws/src/buggy/scripts/watchdog/watchdog.py
+++ b/rb_ws/src/buggy/scripts/watchdog/watchdog.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
+from collections import deque
+
 import argparse
 
 import rospy
 
 from std_msgs.msg import Bool, Int8, Float64
-
-from collections import deque
 
 STEERING_INSTRUCTION_MAX_LEN = 10
 

--- a/rb_ws/src/buggy/scripts/watchdog/watchdog.py
+++ b/rb_ws/src/buggy/scripts/watchdog/watchdog.py
@@ -57,13 +57,15 @@ class Watchdog:
         if self.alarm < 2:
             self.alarm = 0
 
-        # Finds the minimum difference between the stepper's reported angle and the last 10 steering instructions
-        steer_instruct_diff_min = min(
-            map(
-                lambda steer: abs(stepper_steer - steer),
-                self.steering_instructions
+        steer_instruct_diff_min = 0
+        if len(self.steering_instructions) > 0:
+            # Finds the minimum difference between the stepper's reported angle and the last 10 steering instructions
+            steer_instruct_diff_min = min(
+                map(
+                    lambda steer: abs(stepper_steer - steer),
+                    self.steering_instructions
+                )
             )
-        )
 
         if steer_instruct_diff_min > Watchdog.STEERING_DEVIANCE:
             if self.inAutonSteer:


### PR DESCRIPTION
Stores STEERING_INSTRUCTION_MAX_LEN last steering instructions in a deque (which automatically removes excess objects), comparing them with the stepper steering and sending off an error if the minimum difference is too large.
Should smooth over problems related to the out-of-sync-ness of steering and stepper reporting rates.
